### PR TITLE
Fix issue - internet servers appearing in LAN tab

### DIFF
--- a/OpenRVS/classes/OpenMultiPlayerWidget.uc
+++ b/OpenRVS/classes/OpenMultiPlayerWidget.uc
@@ -26,6 +26,8 @@ var config string ServerListURL;//0.8 server list file to load
 var bool bServerSuccess;//0.8 got list of servers from online provider
 var array<string> OpenQueries;//1.5 keep track of servers we've queried
 var OpenTimer Timer;//1.5 ping update
+var OpenServerList OS;//moved here from local - because needed in tab switching function
+var bool bNeedsExtraRefresh;//if going from lan tab to internet, we need an extra refresh forced after the server list is fetched
 
 // QueryReceivedStartPreJoin() (aka PREJOIN) fires when a server query has
 // completed successfully. It is called by the SendMessage() function. In the
@@ -46,7 +48,6 @@ function QueryReceivedStartPreJoin ()
 // Added in 0.8 - made this function load saved URL for server list
 function Created()
 {
-	local OpenServerList OS;
 	super.Created();
 	m_GameService.m_bAutoLISave = false;//0.9 freeze fix - not sure if this does anything but seems to help steam users
 	//LoadConfig("Servers.list");//only load this if fetching server list fails - see NoServerList()
@@ -99,6 +100,11 @@ function FinishedServers()
 {
 	bServerSuccess = true;
 	GetGSServers();
+	if ( bNeedsExtraRefresh )
+	{
+		bNeedsExtraRefresh = false;
+		Refresh(false);
+	}
 }
 
 // GetGSServers() retrieves the current list of servers from the GameService.
@@ -510,6 +516,9 @@ function ManageTabSelection(INT _MPTabChoiceID)
 	{
 		case MultiPlayerTabID.TAB_Lan_Server:
 			m_ConnectionTab = TAB_Lan_Server;
+			ClearServerList();//added to fix bug where internet servers stay in lan tab
+			m_ServerListBox.ClearListOfItems();//fix lan tab
+			m_ServerListBox.m_SelectedItem = none;//fix lan tab
 			if ( m_LanServers.m_GameServerList.length == 0 )
 				Refresh( FALSE );
 			GetLanServers();
@@ -524,7 +533,15 @@ function ManageTabSelection(INT _MPTabChoiceID)
 			m_pLoginWindow.StartLogInProcedure(self);
 			//if ( m_GameService.m_GameServerList.length == 0 )
 			//	Refresh( FALSE );
-			GetGSServers();
+			//when clicking from LAN to internet
+			if ( m_iLastTabSel == MultiPlayerTabID.TAB_Lan_Server )
+			{
+				ClearServerList();
+				bNeedsExtraRefresh = true;//force a refresh once server list fetched
+				if ( OS != none )
+					OS.Init(self,ServerURL,ServerListURL);//fix bug switching between internet/lan tabs - need to refetch server list
+			}
+			//GetGSServers();//commented out - this will get called automatically when openserverlist is done
 			UpdateServerFilters();
 			m_iLastTabSel = MultiPlayerTabID.TAB_Internet_Server;
 			SaveConfig();

--- a/OpenRVS/classes/OpenMultiPlayerWidget.uc
+++ b/OpenRVS/classes/OpenMultiPlayerWidget.uc
@@ -510,8 +510,8 @@ function ManageTabSelection(INT _MPTabChoiceID)
 	{
 		case MultiPlayerTabID.TAB_Lan_Server:
 			m_ConnectionTab = TAB_Lan_Server;
-			//if ( m_LanServers.m_GameServerList.length == 0 )
-			//	Refresh( FALSE );
+			if ( m_LanServers.m_GameServerList.length == 0 )
+				Refresh( FALSE );
 			GetLanServers();
 			GetServerInfo( m_LanServers );
 			UpdateServerFilters();


### PR DESCRIPTION
## Summary

Fixes issue where built list of internet servers are not removed from the list when switching to LAN tab.  Will close issue #29 .  Also fixes issue where internet server info is lost when switching back to internet servers - forces a refetch and refresh of the data.

## Testing

I have tested my compiled build in the following scenarios:

- [x] A client running **my build** against a server running **latest stable version**
- [ ] A client running **latest stable version** against a server running **my build**
- [ ] A client running **my build** against a server running **my build**