### PR TITLE
Cleans up startup message logging

### DIFF
--- a/OpenRVS/classes/OpenCustomMissionWidget.uc
+++ b/OpenRVS/classes/OpenCustomMissionWidget.uc
@@ -106,16 +106,19 @@ function CreateButtons()
 
 //from super
 //now adds U and UTX support to the Mods folder
+//this is the first OpenRVS code which is executed by clients
 function Created()
 {
 	local R6Mod Temp;
+
+	class'OpenLogger'.static.LogStartupMessage();
+
 	super.Created();
 	Temp = class'Actor'.static.GetModMgr().m_pCurrentMod;
 	Temp.m_aExtraPaths[Temp.m_aExtraPaths.length] = "..\\Mods\\*.u";
 	Temp.m_aExtraPaths[Temp.m_aExtraPaths.length] = "..\\Mods\\*.utx";
 	class'Actor'.static.GetModMgr().AddNewModExtraPath(Temp,0);
 }
-
 
 //rewritten from super
 //will get the custom game type if a custom type button is selected

--- a/OpenRVS/classes/OpenMultiPlayerWidget.uc
+++ b/OpenRVS/classes/OpenMultiPlayerWidget.uc
@@ -59,7 +59,7 @@ function Created()
 //openserverlist handles loading the backup list and sending to this class
 function NoServerList()
 {
-	class'OpenLogger'.static.Info("loading backup file Servers.list", self);	
+	class'OpenLogger'.static.Info("loading backup file Servers.list", self);
 	LoadConfig("Servers.list");
 	bServerSuccess = true;//0.8 - leave this here if we want backup server list to get queried too
 	GetGSServers();

--- a/OpenRVS/classes/OpenMultiPlayerWidget.uc
+++ b/OpenRVS/classes/OpenMultiPlayerWidget.uc
@@ -49,13 +49,9 @@ function Created()
 	local OpenServerList OS;
 	super.Created();
 	m_GameService.m_bAutoLISave = false;//0.9 freeze fix - not sure if this does anything but seems to help steam users
-	//LoadConfig("Servers.list");//only load this if fetching server list fails - see NoServerList()
 	LoadConfig("openrvs.ini");//0.8 - see if we need alternate list source
 	OS = Root.Console.ViewportOwner.Actor.spawn(class'OpenServerList');//get the list from Rvsgaming.org or alternate host
 	OS.Init(self,ServerURL,ServerListURL);//0.8 made this load saved config vars in openrvs.ini
-	//DEBUG: read google main page and try to parse it for server list
-	//if working properly, should get the page, discard every line, and log warning that no serverlist was found
-	//OS.Init(self,"www.google.com","index.html");
 }
 
 //couldn't get server list from rvsgaming.org
@@ -63,8 +59,7 @@ function Created()
 //openserverlist handles loading the backup list and sending to this class
 function NoServerList()
 {
-	class'OpenLogger'.static.Info("loading backup file Servers.list", self);
-	//bDONTQUERY = true;//0.8//commented out - we want to query backup list too
+	class'OpenLogger'.static.Info("loading backup file Servers.list", self);	
 	LoadConfig("Servers.list");
 	bServerSuccess = true;//0.8 - leave this here if we want backup server list to get queried too
 	GetGSServers();
@@ -238,7 +233,6 @@ function ShowWindow()
 	//0.9 fix: copy all super into this function and eliminate super call
 	//super.ShowWindow();//0.9 - lag fix
 	local string _szIpAddress;
-	class'OpenLogger'.static.Debug("user opened mp menu", self);
 
 	//BELOW IS FROM SUPER!
 	//important line from 1.6 - not present in 1.56!

--- a/OpenRVS/classes/OpenServerList.uc
+++ b/OpenRVS/classes/OpenServerList.uc
@@ -32,8 +32,6 @@ var string FileName;
 // Starts OpenServerList and send an HTTP request to the server list provider.
 function Init(OpenMultiPlayerWidget Widget, optional string W, optional string F)
 {
-	class'OpenLogger'.static.LogStartupMessage();
-
 	M = Widget;
 	if ( W != "" )
 		WebAddress = W;


### PR DESCRIPTION
## Summary

- Moves `LogStartupMessage()` to `OpenCustomMissionWidget.Created()`, the first code our clients will execute
- Some minor cleanup

## Testing

I have tested my compiled build in the following scenarios:

- [x] A client running **my build** against a server running **latest stable version**
- [ ] A client running **latest stable version** against a server running **my build**
- [ ] A client running **my build** against a server running **my build**

Startup logs on this build:
```
Init: Game engine initialized
Log: Startup time: 3.782100 seconds
Log: Allocating 16384 byte dynamic index buffer.
ScriptLog: 	 ---- OpenRVS ----
ScriptLog: 	 The team: Twi, ijemafe, and Tony
ScriptLog: 	 With thanks to chriswak, Psycho, SMC clan, and SS clan
```