### PR TITLE
Automatically register all OpenRVS servers with the OpenRVS registry

### DIFF
--- a/OpenRVS/classes/OpenServer.uc
+++ b/OpenRVS/classes/OpenServer.uc
@@ -5,7 +5,6 @@
 //Fixes bugs in multi-server lists
 //Sets all pawns as always relevant - important for high ping players
 //installed server side
-
 class OpenServer extends Actor config(BanList);
 
 var bool bLogged, bCracked;
@@ -20,7 +19,17 @@ event PreBeginPlay()
 	openrvs = none;//done initializing
 
 	super.PreBeginPlay();
-	SetTimer(60,true);
+	SetTimer(60, true);
+}
+
+//once everything is initialized, build a beacon text and automatically register
+//this server with the OpenRVS registry.
+event PostNetBeginPlay()
+{
+	super.PostNetBeginPlay();
+
+	//send a UDP beacon to the registry
+	OpenBeacon(R6AbstractGameInfo(Level.Game).m_UdpBeacon).RegisterServer();
 }
 
 //find a player who hasn't been validated

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The IP and port for the deployment can be configured in `openrvs.ini`:
 
 ```ini
 [OpenRVS.OpenBeacon]
-RegistryServerIP=64.225.54.237 ; the current deployment
+RegistryServerIP=64.225.54.237
 RegistryServerPort=8080
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,29 @@ A patch to fix Red Storm Entertainment's mistakes (intentional and otherwise). A
 
 ## To Do
 
-- See GitHub issues list for the complete to-do.  Feel free to request modifications and additions there as well.
+See GitHub issues list for the complete to-do. Feel free to request modifications and additions there as well.
+
+## The OpenRVS Registry
+
+Since v1.5, OpenRVS servers send an extra UDP beacon to a web server running
+[openrvs-registry](https://github.com/ijemafe/openrvs-registry). This app tracks
+all known servers, healthchecks them to hide unhealthy serers, and automatically
+adds new servers to the list when the UDP beacon is received.
+
+The registry listens for beacons on UDP port 8080, and listens for server list
+requests on HTTP port 8080 (on the /servers URL).
+
+The IP and port for the deployment can be configured in `openrvs.ini`:
+
+```ini
+[OpenRVS.OpenBeacon]
+RegistryServerIP=64.225.54.237 # the current deployment
+RegistryServerPort=8080
+```
 
 ## Local Development
 
-**Note: You must test your changes using this process BEFORE opening a pull request!**
+**Note: You should test your changes using this process BEFORE opening a pull request!**
 
 First, you will need to download [Twi's Raven Shield SDK](https://www.moddb.com/mods/raven-shield-software-development-kit). Put this somewhere convenient (such as `C:\rvssdk`).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The IP and port for the deployment can be configured in `openrvs.ini`:
 
 ```ini
 [OpenRVS.OpenBeacon]
-RegistryServerIP=64.225.54.237 # the current deployment
+RegistryServerIP=64.225.54.237 ; the current deployment
 RegistryServerPort=8080
 ```
 


### PR DESCRIPTION
## Summary

In servers only, sends one extra UDP beacon to the OpenRVS registry, automatically adding it to the server list at `http://<RegistryHost>/servers`. Also adds an optional CSV parser (does not replace INI parser unless the file format is the exact CSV we expect).

## Testing

I have tested my compiled build in the following scenarios:

- [x] A client running **my build** against a server running **latest stable version**
- [x] A client running **latest stable version** against a server running **my build**
- [x] A client running **my build** against a server running **my build**