### PR TITLE
Cleans up references to backend servers

### DIFF
--- a/OpenRVS/classes/OpenBeacon.uc
+++ b/OpenRVS/classes/OpenBeacon.uc
@@ -15,6 +15,9 @@ var config int RegistryServerPort;
 const MARKER_MOTD = "O2";
 const MOTD_MAX_LEN = 60;//Container window can only display this many chars
 
+const DEFAULT_REGISTRY_IP = "64.225.54.237";//Host running openrvs-registry
+const DEFAULT_REGISTRY_PORT = 8080;//UDP beacon port
+
 // Fire off automatic server registration.
 function RegisterServer()
 {
@@ -23,9 +26,9 @@ function RegisterServer()
 
 	// Validate input from config file.
 	if (RegistryServerIP == "")
-		RegistryServerIP = "64.225.54.237";//Current openrvs-registry deployment
+		RegistryServerIP = DEFAULT_REGISTRY_IP;
 	if (RegistryServerPort == 0)
-		RegistryServerPort = 8080;
+		RegistryServerPort = DEFAULT_REGISTRY_PORT;
 
 	ok = StringToIpAddr(RegistryServerIP, addr);
 	if (!ok) {

--- a/OpenRVS/classes/OpenRVS.uc
+++ b/OpenRVS/classes/OpenRVS.uc
@@ -1,10 +1,8 @@
 class OpenRVS extends Object;
 
 const OPENRVS_VERSION = "v1.5";
-//note: this is a temporary url on a file server hosting custom maps.
-//this should be moved to rvsgaming.org's file server, or integrated into a
-//server registration app.
-const LATEST_VERSION_URL = "http://64.225.54.237/latest-version.txt";
+// This URL returns the latest release version from GitHub over HTTP.
+const LATEST_VERSION_URL = "http://64.225.54.237/latest";
 
 var OpenHTTPClient httpc;
 


### PR DESCRIPTION
## Summary

I updated the Nginx configs on the server which runs `openrvs-registry`. This PR updates the `/latest` URL to use the Github-backed value from the registry instead of a static file.

## Testing

I have tested my compiled build in the following scenarios:

- [ ] A client running **my build** against a server running **latest stable version**
- [ ] A client running **latest stable version** against a server running **my build**
- [ ] A client running **my build** against a server running **my build**