### PR TITLE
Add simple popup box and version checking on client

### DIFF
--- a/OpenPopUp.uc
+++ b/OpenPopUp.uc
@@ -1,0 +1,16 @@
+class OpenPopUp extends Object;
+
+// A simple object that allows creation of a pop up box at any time, with no concrete references neede
+
+static function OpenPopUpWindow CreatePopUp(optional string sTitle,optional int iWidth,optional int iHeight)
+{
+	local OpenPopUpWindow Window;
+	local Canvas C;
+	
+	C = class'Actor'.static.GetCanvas();
+	if ( ( C == none ) || ( C.Viewport == none ) || ( C.Viewport.Console == none ) )//won't work on a server
+		return none;
+	Window = OpenPopUpWindow(R6Console(C.Viewport.Console).Root.CreateWindow(class'OpenPopUpWindow',0,0,640,480));
+	Window.BuildPopUp(sTitle,iWidth,iHeight);
+	return Window;
+}

--- a/OpenPopUpContent.uc
+++ b/OpenPopUpContent.uc
@@ -1,0 +1,62 @@
+class OpenPopUpContent extends UWindowDialogClientWindow;
+
+var R6WindowWrappedTextArea wTextBox;
+var R6WindowButton butURL;
+var string urlString;
+var float fMargin;
+
+function MakeTextBox()
+{
+	wTextBox = R6WindowWrappedTextArea(CreateWindow(class'R6WindowWrappedTextArea',fMargin,fMargin,WinWidth-(fMargin*2),WinHeight-(fMargin*2),self));
+	wTextBox.m_bDrawBorders = false;
+	wTextBox.SetScrollable(true);
+	wTextBox.VertSB.SetBorderColor(Root.Colors.GrayLight);  
+	wTextBox.VertSB.SetHideWhenDisable(true);
+	wTextBox.VertSB.SetEffect(true);
+}
+
+function AddText(string s,optional bool bBlue)
+{
+	local color c;
+	if ( bBlue )
+		c = Root.Colors.BlueLight;
+	else
+		c = Root.Colors.White;
+	if ( wTextBox == none )
+		MakeTextBox();
+	wTextBox.AddText(s,c,Root.Fonts[F_VerySmallTitle]);
+}
+
+function MakeURLButton(string url,optional string buttonText)
+{
+	if ( url == "" )
+		return;
+	if ( buttonText == "" )
+		buttonText = url;
+	butURL = R6WindowButton(CreateControl(class'R6WindowButton',0,WinHeight-20,WinWidth,16,self));//todo - button could overlap text box bottom
+	butURL.Text = buttonText;
+	butURL.Align = TA_CENTER;
+	butURL.m_buttonFont = Root.Fonts[F_VerySmallTitle];
+	butURL.ResizeToText();
+	urlString = url;
+}
+
+//handles clicking on buttons
+function Notify(UWindowDialogControl C,byte E)
+{ 
+	if ( E == DE_Click )
+	{
+		if ( urlString != "" )
+		{
+			if ( C == butURL )
+			{
+				Root.Console.ConsoleCommand("startminimized"@urlString);
+			}
+		}
+	}    
+}
+
+defaultproperties
+{
+	fMargin=4.0
+}

--- a/OpenPopUpWindow.uc
+++ b/OpenPopUpWindow.uc
@@ -1,0 +1,31 @@
+class OpenPopUpWindow extends R6WindowPopUpBox;
+
+var OpenPopUpContent OpenClient;
+
+function BuildPopUp(optional string sTitle,optional int iWidth,optional int iHeight)
+{
+	if ( sTitle == "" )
+		sTitle = "Please Note:";
+	if ( iWidth == 0 )
+		iWidth = 230;
+	if ( iHeight == 0 )
+		iHeight = 140;
+	CreateStdPopUpWindow(sTitle,30,320 - (iWidth / 2),240 - (iHeight / 2),iWidth,iHeight,2);//auto-centers the box based on width and height
+	CreateClientWindow(class'OpenPopUpContent',false,true);
+	OpenClient = OpenPopUpContent(m_ClientArea);
+	m_ePopUpID = EPopUpID_UbiComDisconnected;
+}
+
+//pass to client window function
+//adds text to the popup
+function AddText(string s,optional bool bBlue)
+{
+	OpenClient.AddText(s,bBlue);
+}
+
+//pass to client window function
+//creates a button that takes user to url at the bottom of the pop up
+function MakeURLButton(string url,optional string buttonText)
+{
+	OpenClient.MakeURLButton(url,buttonText);
+}

--- a/OpenRVS.uc
+++ b/OpenRVS.uc
@@ -1,0 +1,55 @@
+class OpenRVS extends Object;
+
+const OPENRVS_VERSION = "v1.5";
+// This URL returns the latest release version from GitHub over HTTP.
+const LATEST_VERSION_URL = "http://64.225.54.237/latest";
+
+var OpenHTTPClient httpc;
+
+// Init contains the first OpenRVS code which runs. It has a different call
+// location for clients and servers. Clients call Init from
+// OpenCustomMissionWidget, while servers call Init from OpenServer.
+function Init(Actor a)
+{
+	class'OpenLogger'.static.LogStartupMessage();
+
+	// Fire off version-checking request.
+	httpc = a.Spawn(class'OpenHTTPClient');
+	httpc.CallbackName = "version_check";
+	httpc.VersionCheckCallbackProvider = self;
+	httpc.SendRequest(LATEST_VERSION_URL);
+}
+
+function CheckVersion(OpenHTTPClient.HttpResponse resp)
+{
+	local string latest;
+	local string warning;
+	local OpenPopUpWindow WarningWindow;
+
+	if (resp.Code != 200)
+	{
+		class'OpenLogger'.static.Error("failed to retrieve latest version over http", self);
+		return;
+	}
+
+	// Trim the line break.
+	latest = resp.Body;
+//	latest = Left(latest, Len(latest)-1);//WHAT IS THIS? No line break, just trims the 4 out of "v1.4"
+
+	// Log version information to file.
+	// TODO: Also display a popup.
+	if (OPENRVS_VERSION != latest)
+	{
+		warning = "Your copy of the OpenRVS patch is outdated. Your version:" @ OPENRVS_VERSION $ ", latest version:" @ latest;
+		class'OpenLogger'.static.Warning(warning, self);
+		//v1.5 - add pop up box notification to main menu
+		WarningWindow = class'OpenPopUp'.static.CreatePopUp("OpenRVS Patch Check");
+		WarningWindow.AddText("Please note:");
+		WarningWindow.AddText(warning);
+		WarningWindow.AddText("Click the link below to download the latest update.");
+		WarningWindow.AddText("");
+		WarningWindow.MakeURLButton("https://www.moddb.com/search?q=openrvs","Download from ModDB");
+	}
+	else
+		class'OpenLogger'.static.Info("OpenRVS is up to date (" $ latest $ ")", self);
+}

--- a/OpenRVS/classes/OpenRVS.uc
+++ b/OpenRVS/classes/OpenRVS.uc
@@ -23,6 +23,8 @@ function Init(Actor a)
 function CheckVersion(OpenHTTPClient.HttpResponse resp)
 {
 	local string latest;
+	local string warning;
+	local OpenPopUpWindow WarningWindow;
 
 	if (resp.Code != 200)
 	{
@@ -32,12 +34,25 @@ function CheckVersion(OpenHTTPClient.HttpResponse resp)
 
 	// Trim the line break.
 	latest = resp.Body;
-	latest = Left(latest, Len(latest)-1);
+//	latest = Left(latest, Len(latest)-1);//WHAT IS THIS? No line break, just trims the 4 out of "v1.4"
 
 	// Log version information to file.
 	// TODO: Also display a popup.
 	if (OPENRVS_VERSION != latest)
-		class'OpenLogger'.static.Warning("OpenRVS is outdated. Your version:" @ OPENRVS_VERSION $ ", latest version:" @ latest, self);
+	{
+		warning = "Your copy of the OpenRVS patch is outdated. Your version:" @ OPENRVS_VERSION $ ", latest version:" @ latest;
+		class'OpenLogger'.static.Warning(warning, self);
+		//v1.5 - add pop up box notification to main menu
+		WarningWindow = class'OpenPopUp'.static.CreatePopUp("OpenRVS Patch Check");
+		if ( WarningWindow != none )// should be none on server
+		{
+			WarningWindow.AddText("Please note:");
+			WarningWindow.AddText(warning);
+			WarningWindow.AddText("Click the link below to download the latest update.");
+			WarningWindow.AddText("");
+			WarningWindow.MakeURLButton("https://www.moddb.com/search?q=openrvs","Download from ModDB");
+		}
+	}
 	else
 		class'OpenLogger'.static.Info("OpenRVS is up to date (" $ latest $ ")", self);
 }


### PR DESCRIPTION
## Summary

Added functionality for building simple pop up boxes at any time, no need to mess with Ubisoft's convoluted system.  Will contribute to issue #20 for clients.

## Testing

I have tested my compiled build in the following scenarios:

- [X] A client running **my build** against a server running **latest stable version**
- [ ] A client running **latest stable version** against a server running **my build**
- [ ] A client running **my build** against a server running **my build**