### PR TITLE
[1.6] Use `openrvs.org/servers` for the server list

### DIFF
--- a/OpenRVS/classes/OpenMultiPlayerWidget.uc
+++ b/OpenRVS/classes/OpenMultiPlayerWidget.uc
@@ -51,11 +51,11 @@ function Created()
 	super.Created();
 	m_GameService.m_bAutoLISave = false;//0.9 freeze fix - not sure if this does anything but seems to help steam users
 	LoadConfig("openrvs.ini");//0.8 - see if we need alternate list source
-	OS = Root.Console.ViewportOwner.Actor.spawn(class'OpenServerList');//get the list from Rvsgaming.org or alternate host
+	OS = Root.Console.ViewportOwner.Actor.spawn(class'OpenServerList');//get the server list over http
 	OS.Init(self,ServerURL,ServerListURL);//0.8 made this load saved config vars in openrvs.ini
 }
 
-//couldn't get server list from rvsgaming.org
+//couldn't get server list
 //1.3 - this function no longer used!
 //openserverlist handles loading the backup list and sending to this class
 function NoServerList()
@@ -575,8 +575,8 @@ function ManageTabSelection(INT _MPTabChoiceID)
 
 defaultproperties
 {
-	ServerURL="gsconnect.rvsgaming.org"
-	ServerListURL="servers-updated.list"
+	ServerURL="openrvs.org"
+	ServerListURL="servers"
 	//ServerList(0)=(ServerName="SMC Mod Testing",IP="185.24.221.23:7777",MaxPlayers=4,Locked=true,GameMode="coop")
 	//ServerList(1)=(ServerName="ShadowSquadHQ Adver",IP="198.23.145.10:7778",MaxPlayers=16,Locked=false,GameMode="Adver")
 }

--- a/OpenRVS/classes/OpenServerList.uc
+++ b/OpenRVS/classes/OpenServerList.uc
@@ -37,11 +37,11 @@ function Init(OpenMultiPlayerWidget Widget, optional string W, optional string F
 	if ( W != "" )
 		WebAddress = W;
 	else
-		WebAddress = "gsconnect.rvsgaming.org";
+		WebAddress = "openrvs.org";
 	if ( F != "" )
 		FileName = F;
 	else
-		FileName = "servers-updated.list";
+		FileName = "servers";
 
 	httpc = Spawn(class'OpenHTTPClient');
 	httpc.CallbackName = "server_list";

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ By the OpenRVS team:
 
 A patch to fix Red Storm Entertainment's mistakes (intentional and otherwise). Allows multiplayer again, enables more serious modding, implements some QOL fixes.
 
+## Installing
+
+For instructions on installing OpenRVS, see [ModDB](https://www.moddb.com/games/tom-clancys-rainbow-six-3-raven-shield/downloads/raven-shield-openrvs-patch-v15).
+
 ## To Do
 
 See GitHub issues list for the complete to-do. Feel free to request modifications and additions there as well.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ We have included a number of reusable UnrealScript2 libraries in OpenRVS:
 
 - server list now fetches some current info from each server
 - added ability to specify alternate server list source
-- servers loaded from the backup list (if connection to gsconnect.rvsgaming.org fails) also fetch live info
+- servers loaded from the backup list (if connection to the configured server list fails) also fetch live info
 
 #### Beta 0.7
 
@@ -123,7 +123,7 @@ We have included a number of reusable UnrealScript2 libraries in OpenRVS:
 - bypasses UBI.com login
 - bypasses cd key client verification
 - fixes bug in join IP window
-- gets serverlist from rvsgaming.org
+- gets serverlist over http
 - allows connection to LAN server through internet
 - fixes issue with connecting to non-N4 server
 - bypasses cd key server verification


### PR DESCRIPTION
## Summary

For context, we do not control the `rvsgaming.org` domain, and the server list it currently hosts may go down at the end of the month. IMO we should prepare to release OpenRVS 1.6 by this time.

This PR removes references to `rvsgaming.org` and takes the opportunity to use [openrvs-registry](https://github.com.willroberts/openrvs-registry) to fully automate the server list. New servers self-register with the registry, and are immediately available in the server list for clients.

The new default ServerListURL is `openrvs.org/servers`. I have this domain set to auto-renew, and the VM behind it will run indefinitely as it hosts other projects as well.

## Testing

Tested on:

- [x] A client running **my build**